### PR TITLE
Fixed issue where a 4 digit number in the material count would overfl…

### DIFF
--- a/Assets/Scripts/Audio/TreeLevelInterface.cs
+++ b/Assets/Scripts/Audio/TreeLevelInterface.cs
@@ -61,7 +61,7 @@ public class TreeLevelInterface : MonoBehaviour
             if (item.GetComponent<TreeLevelMaterialType>().MaterialType == type)
             {
                 //Update text with value here
-                item.text = (int.Parse(item.text) + value).ToString();
+                item.text = Mathf.Clamp((int.Parse(item.text) + value),0,999).ToString();
             }
         }
     }

--- a/Assets/Scripts/Decoration/Decoration Object/PickupObject.cs
+++ b/Assets/Scripts/Decoration/Decoration Object/PickupObject.cs
@@ -188,15 +188,15 @@ public class PickupObject : MonoBehaviour
         // If the is able to respawn then wait until the correct time then respawn
         else if (Time.time > respawnTime && !isActive && respawnCooldown != 0) Respawn();
 
-        if (Vector2.Distance(transform.position, PlayerController.Instance.transform.position) < pickupOutlineDisplayRange || pickupOutlineDisplayRange == 0)
+        if ((Vector2.Distance(transform.position, PlayerController.Instance.transform.position) < pickupOutlineDisplayRange || pickupOutlineDisplayRange == 0) && health > 0)
         {
-            spriteRef.GetComponent<SpriteRenderer>().material = inRangeMaterial;
             GetComponent<BoxCollider2D>().enabled = true;
+            spriteRef.GetComponent<SpriteRenderer>().material = inRangeMaterial;
         }
         else
         {
-            spriteRef.GetComponent<SpriteRenderer>().material = outRangeMaterial;
             GetComponent<BoxCollider2D>().enabled = false;
+            spriteRef.GetComponent<SpriteRenderer>().material = outRangeMaterial;
         }
             
     }


### PR DESCRIPTION
…ow into 2 lines, fixed bug where pickup objects could still be interacted with after being destroyed.

Material count text is now clamped between 0 and 999. Proximity max interact range now requires the pickup object to have more than 0 health, preventing the object being interacted with at 0 health.