### PR TITLE
Fixed Pickup Object bug and Decoration Selector displaying incorrectl…

### DIFF
--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 1.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 1.prefab
@@ -210,7 +210,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.184
+      value: 1.1981
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 2.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 2.prefab
@@ -210,7 +210,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.593
+      value: 1.658
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 3.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 3.prefab
@@ -210,7 +210,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.341
+      value: 1.401
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 4.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 4.prefab
@@ -166,7 +166,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.675
+      value: -1.691
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 5.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-GardenPlanter 5.prefab
@@ -166,7 +166,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.633
+      value: -1.646
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-PottedPlant.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject-PottedPlant.prefab
@@ -158,11 +158,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4637515757402210686, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.5
+      value: -2.533
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.052
+      value: -0.21
       objectReference: {fileID: 0}
     - target: {fileID: 4637515758312841598, guid: ba88dae99097da043b24de774bcf5e44, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject.prefab
+++ b/Assets/Prefabs/Decoration/Objects/Furniture/FurnitureObject.prefab
@@ -58,7 +58,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: 9f52b5354276c4447adb1a8dc0d2f90a, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -137,6 +137,8 @@ MonoBehaviour:
   <UiName>k__BackingField: NaN
   <UiImage>k__BackingField: {fileID: 0}
   <UiFurnitureCategory>k__BackingField: 0
+  PlacementRequireOnePoint: 0
+  normalModeMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
 --- !u!1 &4637515757402210687
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Decoration/Decoration Object/PickupObject.cs
+++ b/Assets/Scripts/Decoration/Decoration Object/PickupObject.cs
@@ -195,15 +195,30 @@ public class PickupObject : MonoBehaviour
             
             spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
         }
+        // If the player walks out of range of the pickup object or enters a house
         else
         {
+            // Disables the pickup collider preventing the player from interacting with the object
             GetComponent<BoxCollider2D>().enabled = false;
+            
+            // Change to a thin outline to displayer the object being disabled to the player, but still has a thin outline to show it is an interactable object.
             spriteRef.GetComponent<SpriteRenderer>().material = outRangeMaterial;
 
-            if (PlayerController.Instance.CurrentHouse || PlayerController.Instance.CurrentHouse != null) spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 0.25f);
+            // Ensure that no pickup object is being held
+            if (health > 0 && isBeingPulled) CancelPull();
+            
+            if (PlayerController.Instance.CurrentHouse || PlayerController.Instance.CurrentHouse != null)
+            {
+                // While cancel pull above should prevent pickup object being destroyed when entering a house it can be done so this is here to ensure the pickup object is destroyed properly
+                if(health == 0) spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 0);
+                
+                // If pickup object isn't destroyed and player is inside house then become mostly translucent
+                else spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 0.25f);
+            }
+                
+            // After leaving a house ensures that the pickup object is colored correctly
             else if (health > 0) spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
-            if (health > 0) CancelPull();
-            else spriteRef.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 0);
+            
         }
         
 


### PR DESCRIPTION
…y, Fixed Furniture Object preventing leaving edit mode, adjusted Furniture attach points

Fixed bug where pickup objects couldn't be cancelled while holding them due to a scripting oversight which caused cancel pickup to be called every frame, this caused the Decoration selector to not recognise that it was holding a pickup object which preventing the Cancel Pull function from being called.

Furniture objects did not have a material to switch to once out of decoration mode which prevented decoration mode from ending, this caused an error which could softlock the player.

Slightly adjusted attach points on Furniture Objects to allow for easier placement.